### PR TITLE
Update to use -moverlay instead of -fcomrv for overlay flag

### DIFF
--- a/WD-Firmware/demo/build/demos/demo_comrv_baremetal.py
+++ b/WD-Firmware/demo/build/demos/demo_comrv_baremetal.py
@@ -49,8 +49,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_comrv_baremetal_extended.py
+++ b/WD-Firmware/demo/build/demos/demo_comrv_baremetal_extended.py
@@ -49,8 +49,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_comrv_baremetal_multigroup.py
+++ b/WD-Firmware/demo/build/demos/demo_comrv_baremetal_multigroup.py
@@ -49,8 +49,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_comrv_dataoverlay.py
+++ b/WD-Firmware/demo/build/demos/demo_comrv_dataoverlay.py
@@ -49,8 +49,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_comrv_instrumentation.py
+++ b/WD-Firmware/demo/build/demos/demo_comrv_instrumentation.py
@@ -48,8 +48,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_comrv_reset.py
+++ b/WD-Firmware/demo/build/demos/demo_comrv_reset.py
@@ -47,8 +47,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_comrv_rtosal.py
+++ b/WD-Firmware/demo/build/demos/demo_comrv_rtosal.py
@@ -50,8 +50,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_cti.py
+++ b/WD-Firmware/demo/build/demos/demo_cti.py
@@ -49,8 +49,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [

--- a/WD-Firmware/demo/build/demos/demo_cti_rtosal.py
+++ b/WD-Firmware/demo/build/demos/demo_cti_rtosal.py
@@ -57,8 +57,8 @@ class demo(object):
     ]
 
     self.listDemoSpecificCFlags = [
-      # -fcomrv is used to enable llvm support for overlay functions/data
-      '-fcomrv',
+      # -moverlay is used to enable llvm support for overlay functions/data
+      '-moverlay',
     ]
 
     self.listDemoSpecificLinkerFlags = [


### PR DESCRIPTION
This matches an update to the specificaiton where the option to
enable the overlay system in LLVM is now `-moverlay` instead of
`-fcomrv`.